### PR TITLE
explicitly specify input args

### DIFF
--- a/notebooks/13_models_with_memory.ipynb
+++ b/notebooks/13_models_with_memory.ipynb
@@ -194,7 +194,7 @@
     "    numpyro.sample(\"S\", dist.Binomial(N, logits=logit_p), obs=S)\n",
     "\n",
     "\n",
-    "m13_2 = MCMC(NUTS(model), 500, 500, num_chains=4)\n",
+    "m13_2 = MCMC(NUTS(model), num_warmup=500, num_samples=500, num_chains=4)\n",
     "m13_2.run(random.PRNGKey(0), **dat)"
    ]
   },


### PR DESCRIPTION
MCMC(NUTS(model), num_warmup=500, num_samples=500, num_chains=4) 

Current code gives following error (numpyro==0.7.1):
TypeError: __init__() takes 2 positional arguments but 4 positional arguments (and 1 keyword-only argument) were given