### PR TITLE
Update causalgraphicalmodels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpyro
 arviz
-causalgraphicalmodels
+# causalgraphicalmodels compatible with python 3.9+
+causalgraphicalmodels @ git+https://github.com/BirkhoffG/causalgraphicalmodels.git@cd178afc246160d1d0ec996a4ec0652cba580205
 daft


### PR DESCRIPTION
The default causalgraphicalmodels version is not compatible with python 3.9+ ([issue](https://github.com/ijmbarr/causalgraphicalmodels/issues/5#issue-1207611480)). The updated version is compatible with python 3.9+